### PR TITLE
fix(ForeignProxy): remove governance

### DIFF
--- a/contracts/deploy/001_home_proxy.js
+++ b/contracts/deploy/001_home_proxy.js
@@ -11,6 +11,7 @@ const paramsByChainId = {
     foreignChainId: 1,
   },
 };
+// For seer deployment change TOS
 const metadata =
   '{"tos":"ipfs://QmNV5NWwCudYKfiHuhdWxccrPyxs4DnbLGQace2oMKHkZv/Question_Resolution_Policy.pdf", "foreignProxy":true}'; // Same for all chains.
 

--- a/contracts/deploy/002_foreign_proxy.js
+++ b/contracts/deploy/002_foreign_proxy.js
@@ -11,7 +11,8 @@ const paramsByChainId = {
     arbitrator: "0x988b3a538b618c7a603e1c11ab82cd16dbe28069", // KlerosLiquid address
     arbitratorExtraData:
       "0x0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001f", // General Court - 31 jurors
-    inbox: "0x4Dbd4fc535Ac27206064B68FfCf827b0A60BAB3f", // https://docs.arbitrum.io/build-decentralized-apps/reference/useful-addresses
+    inbox: "0x4Dbd4fc535Ac27206064B68FfCf827b0A60BAB3f", // https://docs.arbitrum.io/build-decentralized-apps/reference/contract-addresses
+    // Don't forget to change primary for Seer
     metaEvidence: "TODO", // Need to reupload with different chain ids.
   },
 };
@@ -51,14 +52,10 @@ async function deployForeignProxy({ deployments, getChainId, ethers, config }) {
   const homeProxy = ethers.utils.getContractAddress(transaction);
   console.log(`Home proxy: ${homeProxy}`);
 
-  // Initially have the deployer as governor, and change it later
-  const governor = (await ethers.getSigners())[0].address;
-
   const foreignProxy = await deploy("RealitioForeignProxyArb", {
     from: account.address,
     args: [
       homeProxy,
-      governor,
       arbitrator,
       arbitratorExtraData,
       inbox,

--- a/contracts/src/RealitioForeignProxyArb.sol
+++ b/contracts/src/RealitioForeignProxyArb.sol
@@ -27,6 +27,7 @@ contract RealitioForeignProxyArb is IForeignArbitrationProxy, IDisputeResolver {
     uint256 public constant MULTIPLIER_DIVISOR = 10000; // Divisor parameter for multipliers.
     uint256 private constant L2_CALL_VALUE = 0; // The msg.value for L2 tx. Always 0.
     uint256 private constant BLOCK_BASE_FEE = 0; // Block baseFee is set to 0 to use current block's baseFee.
+    uint256 public constant META_EVIDENCE_ID = 0; // The ID of the MetaEvidence for disputes.
 
     /* Storage */
 
@@ -45,9 +46,6 @@ contract RealitioForeignProxyArb is IForeignArbitrationProxy, IDisputeResolver {
         uint256 disputeID; // The ID of the dispute in arbitrator contract.
         uint256 answer; // The answer given by the arbitrator.
         Round[] rounds; // Tracks each appeal round of a dispute.
-        IArbitrator arbitrator; // The arbitrator trusted to solve disputes for this request.
-        bytes arbitratorExtraData; // The extra data for the trusted arbitrator of this request.
-        uint256 metaEvidenceID; // The meta evidence to be used in a dispute for this case.
     }
 
     struct DisputeDetails {
@@ -66,33 +64,31 @@ contract RealitioForeignProxyArb is IForeignArbitrationProxy, IDisputeResolver {
 
     address public immutable homeProxy; // Proxy on L2.
 
-    address public governor; // Governor of the contract (e.g KlerosGovernor).
-    IArbitrator public arbitrator; // The address of the arbitrator. TRUSTED.
+    IArbitrator public immutable arbitrator; // The address of the arbitrator. TRUSTED.
     bytes public arbitratorExtraData; // The extra data used to raise a dispute in the arbitrator.
-    uint256 public metaEvidenceUpdates; // The number of times the meta evidence has been updated. Used to track the latest meta evidence ID.
     
-    IInbox public inbox; // Arbitrum inbox contract.
+    IInbox public immutable inbox; // Arbitrum inbox contract.
     // Note that setting gasPriceBid to 0 will result in immediate revert on L1.
-    // If the values are set too low the tx won't redeed itself automatically on L2. The deposit will be reimbursed and manual redeem will be activated.
+    // If the values are set too low the tx won't redeem itself automatically on L2. The deposit will be reimbursed and manual redeem will be activated.
     // It can be done here https://retryable-dashboard.arbitrum.io/tx
     // Preferred values for gasLimit and gasPriceBid are 1500000 and 1000000000 respectively. This values are greatly higher than required amount to ensure automatic redeem.
-    uint256 public l2GasLimit; // Gas limit for tx on L2.
-    uint256 public gasPriceBid; // Gas price bid for tx on L2.
+    uint256 public immutable l2GasLimit; // Gas limit for tx on L2.
+    uint256 public immutable gasPriceBid; // Gas price bid for tx on L2.
 
     // The amount to add to arbitration fees to cover for Arbitrum fees. The leftover will be reimbursed. This is required for Realtio UI.
     // Surplus amount covers submission cost for retryable ticket on L1 + gasLimit * gasPriceBid.
-    // Submission cost is based on the length of the passed message and current gas fees. It's usually greatly lower than 0.05 but it's preferred to use this value
-    // to account for potential gas fee spikes. It shouldn't be an issue since 0.05 is a relatively low value compared to Kleros arbitration cost
+    // Submission cost is based on the length of the passed message and current gas fees. It's usually greatly lower than 0.03 but it's preferred to use this value
+    // to account for potential gas fee spikes. It shouldn't be an issue since 0.03 is a relatively low value compared to Kleros arbitration cost
     // and the leftover will be reimbursed anyway.
-    uint256 public surplusAmount; 
+    uint256 public immutable surplusAmount; 
 
     // Multipliers are in basis points.
-    uint256 public winnerMultiplier; // Multiplier for calculating the appeal fee that must be paid for the answer that was chosen by the arbitrator in the previous round.
-    uint256 public loserMultiplier; // Multiplier for calculating the appeal fee that must be paid for the answer that the arbitrator didn't rule for in the previous round.
-    uint256 public loserAppealPeriodMultiplier; // Multiplier for calculating the duration of the appeal period for the loser, in basis points.
+    uint256 public immutable winnerMultiplier; // Multiplier for calculating the appeal fee that must be paid for the answer that was chosen by the arbitrator in the previous round.
+    uint256 public immutable loserMultiplier; // Multiplier for calculating the appeal fee that must be paid for the answer that the arbitrator didn't rule for in the previous round.
+    uint256 public immutable loserAppealPeriodMultiplier; // Multiplier for calculating the duration of the appeal period for the loser, in basis points.
 
     mapping(uint256 => mapping(address => ArbitrationRequest)) public arbitrationRequests; // Maps arbitration ID to its data. arbitrationRequests[uint(questionID)][requester].
-    mapping(address => mapping(uint256 => DisputeDetails)) public arbitratorDisputeIDToDisputeDetails; // Maps external dispute ids from a particular arbitrator to local arbitration ID and requester who was able to complete the arbitration request.
+    mapping(uint256 => DisputeDetails) public disputeIDToDisputeDetails; // Maps external dispute ids to local arbitration ID and requester who was able to complete the arbitration request.
     mapping(uint256 => bool) public arbitrationIDToDisputeExists; // Whether a dispute has already been created for the given arbitration ID or not.
     mapping(uint256 => address) public arbitrationIDToRequester; // Maps arbitration ID to the requester who was able to complete the arbitration request.
     mapping(uint256 => uint256) public arbitrationCreatedBlock; // Block of dispute creation.
@@ -108,16 +104,9 @@ contract RealitioForeignProxyArb is IForeignArbitrationProxy, IDisputeResolver {
         require(l2Sender == homeProxy, "Can only be called by Home proxy");
         _;
     }
-
-    modifier onlyGovernor() {
-        require(msg.sender == governor, "The caller must be the governor."); 
-        _;
-    }
-
     /**
      * @notice Creates an arbitration proxy on the foreign chain (L1).
      * @param _homeProxy Proxy on L2.
-     * @param _governor Governor of the contract.
      * @param _arbitrator Arbitrator contract address.
      * @param _arbitratorExtraData The extra data used to raise a dispute in the arbitrator.
      * @param _inbox L2 inbox.
@@ -132,7 +121,6 @@ contract RealitioForeignProxyArb is IForeignArbitrationProxy, IDisputeResolver {
      */
     constructor(
         address _homeProxy,
-        address _governor,
         IArbitrator _arbitrator,
         bytes memory _arbitratorExtraData,
         address _inbox,
@@ -143,7 +131,6 @@ contract RealitioForeignProxyArb is IForeignArbitrationProxy, IDisputeResolver {
         uint256[3] memory _multipliers
     ) {
         homeProxy = _homeProxy;
-        governor = _governor;
         arbitrator = _arbitrator;
         arbitratorExtraData = _arbitratorExtraData;
         inbox = IInbox(_inbox);
@@ -154,97 +141,10 @@ contract RealitioForeignProxyArb is IForeignArbitrationProxy, IDisputeResolver {
         loserMultiplier = _multipliers[1];
         loserAppealPeriodMultiplier = _multipliers[2];
 
-        emit MetaEvidence(metaEvidenceUpdates, _metaEvidence);
+        emit MetaEvidence(META_EVIDENCE_ID, _metaEvidence);
     }
 
     /* External and public */
-
-    /**
-     * @notice Changes the governor of the contract.
-     * @param _governor New governor address.
-     */
-    function changeGovernor(address _governor) external onlyGovernor {
-        governor = _governor;
-    }
-    
-    /**
-     * @notice Changes the arbitrator and extradata. The arbitrator is trusted to support appeal period and not reenter.
-     * Note avoid changing arbitrator if there is an active arbitration request in Requested phase, otherwise evidence submitted during this phase
-     * will be submitted to the new arbitrator, while arbitration request will be processed by the old one. 
-     * @param _arbitrator New arbitrator address.
-     * @param _arbitratorExtraData Extradata for the arbitrator 
-     */
-    function changeArbitrator(IArbitrator _arbitrator, bytes calldata _arbitratorExtraData) external onlyGovernor {
-        arbitrator = _arbitrator;
-        arbitratorExtraData = _arbitratorExtraData;
-    }
-
-    /**
-     * @notice Updates the meta evidence used for disputes.
-     * @param _metaEvidence Metaevidence URI.
-     */
-    function changeMetaevidence(string memory _metaEvidence) external onlyGovernor {
-        metaEvidenceUpdates++;
-        emit MetaEvidence(metaEvidenceUpdates, _metaEvidence);
-    }
-
-    /**
-     * @notice Changes the address of Arbitrum inbox contract.
-     * Note avoid changing the address if there is an active L2->L1 message being processed since the new inbox will most likely reference a new bridge address
-     * thus making onlyL2Bridge modifier fail.
-     * @param _inbox New inbox address.
-     */
-    function changeInbox(IInbox _inbox) external onlyGovernor {
-        inbox = _inbox;
-    }
-
-    /**
-     * @notice Changes the L2 gas limit value.
-     * @param _l2GasLimit New L2 gas limit.
-     */
-    function changeL2GasLimit(uint256 _l2GasLimit) external onlyGovernor {
-        l2GasLimit = _l2GasLimit;
-    }
-
-    /**
-     * @notice Changes the L2 gas price bid value.
-     * @param _gasPriceBid New L2 gas price bid.
-     */
-    function changeGasPriceBid(uint256 _gasPriceBid) external onlyGovernor {
-        gasPriceBid = _gasPriceBid;
-    }
-
-    /**
-     * @notice Changes the surplus amount to cover the arbitrum fees.
-     * @param _surplus New surplus value.
-     */
-    function changeSurplus(uint256 _surplus) external onlyGovernor {
-        surplusAmount = _surplus;
-    }
-
-    /**
-     * @notice Changes winner multiplier value.
-     * @param _winnerMultiplier New winner multiplier.
-     */
-    function changeWinnerMultiplier(uint256 _winnerMultiplier) external onlyGovernor {
-        winnerMultiplier = _winnerMultiplier;
-    }
-
-    /**
-     * @notice Changes loser multiplier value.
-     * @param _loserMultiplier New loser multiplier.
-     */
-    function changeLoserMultiplier(uint256 _loserMultiplier) external onlyGovernor {
-        loserMultiplier = _loserMultiplier;
-    }
-
-    /**
-     * @notice Changes loser multiplier for appeal period.
-     * @param _loserAppealPeriodMultiplier New loser multiplier for appeal period.
-     */
-    function changeLoserAppealPeriodMultiplier(uint256 _loserAppealPeriodMultiplier) external onlyGovernor {
-        loserAppealPeriodMultiplier = _loserAppealPeriodMultiplier;
-    }
 
     // ************************ //
     // *    Realitio logic    * //
@@ -260,10 +160,6 @@ contract RealitioForeignProxyArb is IForeignArbitrationProxy, IDisputeResolver {
 
         ArbitrationRequest storage arbitration = arbitrationRequests[uint256(_questionID)][msg.sender];
         require(arbitration.status == Status.None, "Arbitration already requested");
-
-        arbitration.arbitrator = arbitrator;
-        arbitration.arbitratorExtraData = arbitratorExtraData;
-        arbitration.metaEvidenceID = metaEvidenceUpdates;
 
         bytes4 methodSelector = IHomeArbitrationProxy.receiveArbitrationRequest.selector;
         bytes memory data = abi.encodeWithSelector(methodSelector, _questionID, msg.sender, _maxPrevious);
@@ -304,12 +200,12 @@ contract RealitioForeignProxyArb is IForeignArbitrationProxy, IDisputeResolver {
         require(arbitration.status == Status.Requested, "Invalid arbitration status");
 
         // Arbitration cost can possibly change between when the request has been made and received, so evaluate once more.
-        uint256 arbitrationCost = arbitration.arbitrator.arbitrationCost(arbitration.arbitratorExtraData);
+        uint256 arbitrationCost = arbitrator.arbitrationCost(arbitratorExtraData);
         if (arbitration.deposit >= arbitrationCost) {
             try
-                arbitration.arbitrator.createDispute{value: arbitrationCost}(NUMBER_OF_CHOICES_FOR_ARBITRATOR, arbitration.arbitratorExtraData)
+                arbitrator.createDispute{value: arbitrationCost}(NUMBER_OF_CHOICES_FOR_ARBITRATOR, arbitratorExtraData)
             returns (uint256 disputeID) {
-                DisputeDetails storage disputeDetails = arbitratorDisputeIDToDisputeDetails[address(arbitration.arbitrator)][disputeID];
+                DisputeDetails storage disputeDetails = disputeIDToDisputeDetails[disputeID];
                 disputeDetails.arbitrationID = arbitrationID;
                 disputeDetails.requester = _requester;
 
@@ -330,7 +226,7 @@ contract RealitioForeignProxyArb is IForeignArbitrationProxy, IDisputeResolver {
                 }
 
                 emit ArbitrationCreated(_questionID, _requester, disputeID);
-                emit Dispute(arbitration.arbitrator, disputeID, arbitration.metaEvidenceID, arbitrationID);
+                emit Dispute(arbitrator, disputeID, META_EVIDENCE_ID, arbitrationID);
             } catch {
                 arbitration.status = Status.Failed;
                 emit ArbitrationFailed(_questionID, _requester);
@@ -416,12 +312,12 @@ contract RealitioForeignProxyArb is IForeignArbitrationProxy, IDisputeResolver {
         require(arbitration.status == Status.Created, "No dispute to appeal.");
 
         uint256 disputeID = arbitration.disputeID;
-        (uint256 appealPeriodStart, uint256 appealPeriodEnd) = arbitration.arbitrator.appealPeriod(disputeID);
+        (uint256 appealPeriodStart, uint256 appealPeriodEnd) = arbitrator.appealPeriod(disputeID);
         require(block.timestamp >= appealPeriodStart && block.timestamp < appealPeriodEnd, "Appeal period is over.");
 
         uint256 multiplier;
         {
-            uint256 winner = arbitration.arbitrator.currentRuling(disputeID);
+            uint256 winner = arbitrator.currentRuling(disputeID);
             if (winner == _answer) {
                 multiplier = winnerMultiplier;
             } else {
@@ -437,7 +333,7 @@ contract RealitioForeignProxyArb is IForeignArbitrationProxy, IDisputeResolver {
         uint256 lastRoundID = arbitration.rounds.length - 1;
         Round storage round = arbitration.rounds[lastRoundID];
         require(!round.hasPaid[_answer], "Appeal fee is already paid.");
-        uint256 appealCost = arbitration.arbitrator.appealCost(disputeID, arbitration.arbitratorExtraData);
+        uint256 appealCost = arbitrator.appealCost(disputeID, arbitratorExtraData);
         uint256 totalCost = appealCost + ((appealCost * multiplier) / MULTIPLIER_DIVISOR);
 
         // Take up to the amount necessary to fund the current round at the current costs.
@@ -460,7 +356,7 @@ contract RealitioForeignProxyArb is IForeignArbitrationProxy, IDisputeResolver {
             arbitration.rounds.push();
 
             round.feeRewards = round.feeRewards - appealCost;
-            arbitration.arbitrator.appeal{value: appealCost}(disputeID, arbitration.arbitratorExtraData);
+            arbitrator.appeal{value: appealCost}(disputeID, arbitratorExtraData);
         }
 
         if (msg.value - contribution > 0) payable(msg.sender).send(msg.value - contribution); // Sending extra value back to contributor. It is the user's responsibility to accept ETH.
@@ -536,14 +432,7 @@ contract RealitioForeignProxyArb is IForeignArbitrationProxy, IDisputeResolver {
      * @param _evidenceURI Link to evidence.
      */
     function submitEvidence(uint256 _arbitrationID, string calldata _evidenceURI) external override {
-        address requester = arbitrationIDToRequester[_arbitrationID];
-        ArbitrationRequest storage arbitration = arbitrationRequests[_arbitrationID][requester];
-        if (address(arbitration.arbitrator) == address(0)) { //None or Requested status.
-            // Note that arbitrator set during requestArbitration might differ from default arbitrator, if default arbitrator was changed during Requested status.
-            emit Evidence(arbitrator, _arbitrationID, msg.sender, _evidenceURI);
-        } else {
-            emit Evidence(arbitration.arbitrator, _arbitrationID, msg.sender, _evidenceURI);     
-        }
+        emit Evidence(arbitrator, _arbitrationID, msg.sender, _evidenceURI);
     }
 
     /**
@@ -553,12 +442,12 @@ contract RealitioForeignProxyArb is IForeignArbitrationProxy, IDisputeResolver {
      * @param _ruling The ruling given by the arbitrator.
      */
     function rule(uint256 _disputeID, uint256 _ruling) external override {
-        DisputeDetails storage disputeDetails = arbitratorDisputeIDToDisputeDetails[msg.sender][_disputeID];
+        DisputeDetails storage disputeDetails = disputeIDToDisputeDetails[_disputeID];
         uint256 arbitrationID = disputeDetails.arbitrationID;
         address requester = disputeDetails.requester;
 
         ArbitrationRequest storage arbitration = arbitrationRequests[arbitrationID][requester];
-        require(msg.sender == address(arbitration.arbitrator), "Only arbitrator allowed");
+        require(msg.sender == address(arbitrator), "Only arbitrator allowed");
         require(arbitration.status == Status.Created, "Invalid arbitration status");
         uint256 finalRuling = _ruling;
 
@@ -568,7 +457,7 @@ contract RealitioForeignProxyArb is IForeignArbitrationProxy, IDisputeResolver {
 
         arbitration.answer = finalRuling;
         arbitration.status = Status.Ruled;
-        emit Ruling(IArbitrator(msg.sender), _disputeID, finalRuling);
+        emit Ruling(arbitrator, _disputeID, finalRuling);
     }
 
     /**
@@ -785,12 +674,7 @@ contract RealitioForeignProxyArb is IForeignArbitrationProxy, IDisputeResolver {
      * @return localDisputeID Dispute id as in arbitrable contract.
      */
     function externalIDtoLocalID(uint256 _externalDisputeID) external view override returns (uint256) {
-        // Note that in case of arbitrator's change external dispute from the new arbitrator
-        // will overwrite the external dispute with the same ID from the old arbitrator,
-        // which will make the data related to the old arbitrator's dispute unaccessible in DisputeResolver's UI.
-        // It should be fine since the dispute will be closed anyway.
-        // Ideally we would want to have arbitrator's address as one of the parameters, but we can't break the interface.
-        return arbitratorDisputeIDToDisputeDetails[address(arbitrator)][_externalDisputeID].arbitrationID;
+        return disputeIDToDisputeDetails[_externalDisputeID].arbitrationID;
     }
 
     /**


### PR DESCRIPTION
Governance removed to avoid overengineering. In case a change of the parameters is needed the contract needs to be redeployed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Added a constant for MetaEvidence ID in the arbitration contract

- **Refactor**
	- Simplified contract governance by removing governor-related functions
	- Converted multiple contract variables to immutable, enhancing contract security
	- Streamlined dispute management by updating dispute details mapping

- **Documentation**
	- Updated comments for deployment scripts and contract addresses

- **Tests**
	- Removed governance-related test cases to align with new contract structure

<!-- end of auto-generated comment: release notes by coderabbit.ai -->